### PR TITLE
Fixed href

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
-.env*
+.env
 
 # vercel
 .vercel

--- a/apps/iotricity/.env.example
+++ b/apps/iotricity/.env.example
@@ -1,0 +1,1 @@
+NODE_ENV = "development"

--- a/apps/iotricity/src/app/page.tsx
+++ b/apps/iotricity/src/app/page.tsx
@@ -9,7 +9,6 @@ import Accordion from "@/components/ui/Accordion";
 import Button from "@/components/ui/Button";
 import Divider2 from "@/components/ui/Divider";
 import Headlines from "@/components/ui/Headlines";
-import MentorsCard from "@/components/ui/MentorsCard";
 import { ArrowRight, ExternalLink } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
@@ -391,7 +390,7 @@ const HomePage = () => {
         <Divider2 />
 
         {/* Mentors Section */}
-        <div className="w-[calc(100%-30px)] lg:w-[calc(100%-14rem)] mx-auto border-[0.5px] border-gray-500 border-t-0 border-b-0">
+        {/* <div className="w-[calc(100%-30px)] lg:w-[calc(100%-14rem)] mx-auto border-[0.5px] border-gray-500 border-t-0 border-b-0">
           <div className="flex items-center border-gray-500 border-b-[0.5px] overflow-hidden">
             <Headlines headLine="Mentors" />
           </div>
@@ -407,7 +406,7 @@ const HomePage = () => {
             ))}
           </div>
         </div>
-        <Divider2 />
+        <Divider2 /> */}
 
         {/* FAQ Section */}
         <div className="w-[calc(100%-30px)] lg:w-[calc(100%-14rem)] mx-auto border-[0.5px] border-gray-500 border-t-0 border-b-0">

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,1 @@
+NODE_ENV = "development"

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -298,7 +298,14 @@ const HomePage = () => {
 
                 {/* Checkout Button */}
                 <div className="flex justify-center">
-                  <Link href="/iotricity" className="w-full sm:w-auto max-w-xs">
+                  <Link
+                    href={
+                      process.env.NODE_ENV === "development"
+                        ? "http://localhost:3001"
+                        : "https://iotricity.sceeaot.in"
+                    }
+                    className="w-full sm:w-auto max-w-xs"
+                  >
                     <Button
                       variant="primary"
                       size="lg"
@@ -331,7 +338,14 @@ const HomePage = () => {
                       </Button>
                     </Link>
                   )}
-                  <Link href="/iotricity" className="w-full sm:w-auto">
+                  <Link
+                    href={
+                      process.env.NODE_ENV === "development"
+                        ? "http://localhost:3001"
+                        : "https://iotricity.sceeaot.in"
+                    }
+                    className="w-full sm:w-auto"
+                  >
                     <Button
                       variant="secondary"
                       icon={<ExternalLink size={18} />}


### PR DESCRIPTION
This pull request introduces environment-specific configuration and UI adjustments for the `iotricity` and `web` applications. The main changes involve adding a `NODE_ENV` variable to example environment files, updating navigation links to use different URLs based on the environment, and temporarily removing the Mentors section from the `iotricity` homepage.

**Environment configuration:**

* Added `NODE_ENV = "development"` to both `apps/iotricity/.env.example` and `apps/web/.env.example` to standardize environment variable usage.

**UI updates and conditional navigation:**

* Updated the `/iotricity` navigation links in `apps/web/src/app/page.tsx` to use `http://localhost:3001` in development and `https://iotricity.sceeaot.in` in production, ensuring the correct endpoint is used based on the environment. [[1]](diffhunk://#diff-938e7f0bd43c2bd57de5c1764a620c59bc7deea9b9cab3705a5eafac46839c8cL301-R308) [[2]](diffhunk://#diff-938e7f0bd43c2bd57de5c1764a620c59bc7deea9b9cab3705a5eafac46839c8cL334-R348)

**Feature toggling:**

* Commented out the Mentors section in the `iotricity` homepage (`apps/iotricity/src/app/page.tsx`), effectively removing it from the UI for now. [[1]](diffhunk://#diff-e69782517ee677fd9706cfc44e53ecff15de14cad119d8230070d8adc10ec639L12) [[2]](diffhunk://#diff-e69782517ee677fd9706cfc44e53ecff15de14cad119d8230070d8adc10ec639L394-R393) [[3]](diffhunk://#diff-e69782517ee677fd9706cfc44e53ecff15de14cad119d8230070d8adc10ec639L410-R409)