### PR TITLE
Added Analytics

### DIFF
--- a/apps/iotricity/package.json
+++ b/apps/iotricity/package.json
@@ -9,6 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@vercel/analytics": "^1.5.0",
+    "@vercel/speed-insights": "^1.2.0",
     "clsx": "^2.1.1",
     "eslint-plugin-react": "^7.37.4",
     "eslint-plugin-tailwindcss": "^3.18.0",

--- a/apps/iotricity/src/app/layout.tsx
+++ b/apps/iotricity/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import { LoadingProvider } from "@/components/providers/LoadingProvider";
 import LayoutWrapper from "@/components/ui/LayoutWrapper";
+import { Analytics } from "@vercel/analytics/next";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
@@ -68,6 +70,8 @@ export default function RootLayout({
         <LoadingProvider>
           <LayoutWrapper>{children}</LayoutWrapper>
         </LoadingProvider>
+        <Analytics />
+        <SpeedInsights />
       </body>
     </html>
   );

--- a/apps/links/package.json
+++ b/apps/links/package.json
@@ -9,6 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@vercel/analytics": "^1.5.0",
+    "@vercel/speed-insights": "^1.2.0",
     "clsx": "^2.1.1",
     "eslint-plugin-react": "^7.37.4",
     "eslint-plugin-tailwindcss": "^3.18.0",

--- a/apps/links/src/app/layout.tsx
+++ b/apps/links/src/app/layout.tsx
@@ -1,4 +1,6 @@
 import { LoadingProvider } from "@/components/providers/LoadingProvider";
+import { Analytics } from "@vercel/analytics/next";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
@@ -67,6 +69,8 @@ export default function RootLayout({
         <LoadingProvider>
           <div>{children}</div>
         </LoadingProvider>
+        <Analytics />
+        <SpeedInsights />
       </body>
     </html>
   );

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,6 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@vercel/analytics": "^1.5.0",
+    "@vercel/speed-insights": "^1.2.0",
     "clsx": "^2.1.1",
     "eslint-plugin-react": "^7.37.4",
     "eslint-plugin-tailwindcss": "^3.18.0",

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import { LoadingProvider } from "@/components/providers/LoadingProvider";
 import LayoutWrapper from "@/components/ui/LayoutWrapper";
+import { Analytics } from "@vercel/analytics/next";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
@@ -69,6 +71,8 @@ export default function RootLayout({
         <LoadingProvider>
           <LayoutWrapper>{children}</LayoutWrapper>
         </LoadingProvider>
+        <Analytics />
+        <SpeedInsights />
       </body>
     </html>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,12 @@ importers:
 
   apps/iotricity:
     dependencies:
+      '@vercel/analytics':
+        specifier: ^1.5.0
+        version: 1.5.0(next@15.4.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
+      '@vercel/speed-insights':
+        specifier: ^1.2.0
+        version: 1.2.0(next@15.4.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -78,6 +84,12 @@ importers:
 
   apps/links:
     dependencies:
+      '@vercel/analytics':
+        specifier: ^1.5.0
+        version: 1.5.0(next@15.4.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
+      '@vercel/speed-insights':
+        specifier: ^1.2.0
+        version: 1.2.0(next@15.4.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -136,6 +148,12 @@ importers:
 
   apps/web:
     dependencies:
+      '@vercel/analytics':
+        specifier: ^1.5.0
+        version: 1.5.0(next@15.4.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
+      '@vercel/speed-insights':
+        specifier: ^1.2.0
+        version: 1.2.0(next@15.4.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -747,6 +765,55 @@ packages:
     resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
     cpu: [x64]
     os: [win32]
+
+  '@vercel/analytics@1.5.0':
+    resolution: {integrity: sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
+
+  '@vercel/speed-insights@1.2.0':
+    resolution: {integrity: sha512-y9GVzrUJ2xmgtQlzFP2KhVRoCglwfRQgjyfY607aU0hh0Un6d0OUyrJkjuAlsV18qR4zfoFPs/BiIj9YDS6Wzw==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -2568,6 +2635,16 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
+
+  '@vercel/analytics@1.5.0(next@15.4.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)':
+    optionalDependencies:
+      next: 15.4.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+
+  '@vercel/speed-insights@1.2.0(next@15.4.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)':
+    optionalDependencies:
+      next: 15.4.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:


### PR DESCRIPTION
This pull request adds Vercel Analytics and Speed Insights to the `iotricity`, `links`, and `web` apps to enable performance monitoring and analytics. The changes include updating dependencies, modifying layout files to include the new components, and updating the lockfile to reflect these additions.

**Dependency and Monitoring Integration:**

* Added `@vercel/analytics` and `@vercel/speed-insights` as dependencies to `apps/iotricity/package.json`, `apps/links/package.json`, and `apps/web/package.json` to enable analytics and performance insights. [[1]](diffhunk://#diff-7e0bbed1159dc6c109bf8e6c24860c4d2ac0ac4f577ed52bacf85d9c7eaafc8cR12-R13) [[2]](diffhunk://#diff-eed22072aea25f3a349bfb37dd8f894ff4978c3681e85ca6ea3821ca5da3e57fR12-R13) [[3]](diffhunk://#diff-14b60f636e1a2b0061da57aaf231cb1ed15a5dc0c592425ed82e58fec95d42d8R12-R13)
* Updated `pnpm-lock.yaml` to include the new packages and their required peer dependencies, ensuring proper installation and version locking. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR23-R28) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR87-R92) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR151-R156) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR769-R817) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2639-R2648)

**App Layout Updates:**

* Imported and rendered the `Analytics` and `SpeedInsights` components from the new dependencies in the root layout files for all three apps (`apps/iotricity/src/app/layout.tsx`, `apps/links/src/app/layout.tsx`, `apps/web/src/app/layout.tsx`), ensuring analytics scripts are loaded on every page. [[1]](diffhunk://#diff-d681855afbf923335770eb6f85a09df8168f4d28d41a34c0730c711f316246f3R3-R4) [[2]](diffhunk://#diff-d681855afbf923335770eb6f85a09df8168f4d28d41a34c0730c711f316246f3R73-R74) [[3]](diffhunk://#diff-d3da4ac26dfbd36ca2b1129ebe98c173624b7a3f5a006885dc1639209566ba28R2-R3) [[4]](diffhunk://#diff-d3da4ac26dfbd36ca2b1129ebe98c173624b7a3f5a006885dc1639209566ba28R72-R73) [[5]](diffhunk://#diff-111ec756d646fc7ecca7118cc675dedf7fde956e903db45ed91fbfd0fc111419R3-R4) [[6]](diffhunk://#diff-111ec756d646fc7ecca7118cc675dedf7fde956e903db45ed91fbfd0fc111419R74-R75)