### PR TITLE
feat: updated cinematics

### DIFF
--- a/apps/iotricity/src/app/page.tsx
+++ b/apps/iotricity/src/app/page.tsx
@@ -328,14 +328,14 @@ const HomePage = () => {
         </div>
         <Divider2 />
 
-        {/* Registration Guide Section */}
+        {/* Post Event Cinematics Section */}
         <div className="w-[calc(100%-30px)] lg:w-[calc(100%-14rem)] mx-auto border-[0.5px] border-gray-500 border-t-0 border-b-0">
           {/* Unified Header Section */}
           <div className="lg:flex lg:h-[10rem]">
             {/* Headline Section */}
             <div className="flex items-center border-gray-500 border-b-[0.5px] lg:border-b-[0.8px] lg:border-r-[0.8px] lg:w-1/2 lg:pl-[1.6rem] overflow-hidden">
               <div className="block lg:hidden w-full">
-                <Headlines headLine="Registration Guide" />
+                <Headlines headLine="Post Event Cinematics" />
               </div>
               <h1
                 className="hidden lg:block text-[94px] font-bold leading-[72px] tracking-[-0.47px]"
@@ -345,9 +345,7 @@ const HomePage = () => {
                   color: "transparent",
                 }}
               >
-                Registration
-                <br />
-                Guide
+                Cinematics
               </h1>
             </div>
 
@@ -356,7 +354,7 @@ const HomePage = () => {
               <div className="flex-1 lg:absolute lg:inset-0 lg:bg-black/20">
                 <img
                   src="/images/GIF.gif"
-                  alt="Registration Guide GIF"
+                  alt="Post Event Cinematics GIF"
                   className="w-full h-[3.75rem] lg:w-full lg:h-full object-cover"
                   style={{
                     backgroundSize: "cover",
@@ -370,11 +368,9 @@ const HomePage = () => {
           {/* Video Content */}
           <div className="px-[1.40625rem] lg:px-8 py-[1.40625rem] lg:py-8">
             {/* Description Text */}
-            <div className="text-[10.5px] lg:text-[1.2rem] font-light leading-relaxed font-pxg text-left lg:text-center mb-8">
-              Watch our comprehensive registration guide to learn how to
-              register for IOTricity Season 2.0. This video will walk you
-              through the entire registration process step by step, ensuring you
-              don't miss any important details.
+            <div className="text-[10.5px] lg:text-[1rem] font-light leading-relaxed font-pxg text-left lg:text-center mb-8">
+              🚀 The wait is over! Relive the energy, innovation, and excitement
+              of Iotricity Season 2 - D-Day Finale 🎥✨
             </div>
 
             {/* YouTube Video Embed */}
@@ -385,8 +381,8 @@ const HomePage = () => {
                   {/* 16:9 aspect ratio */}
                   <iframe
                     className="absolute top-0 left-0 w-full h-full rounded-lg border border-primary/20"
-                    src="https://www.youtube.com/embed/MdUBB_78c6I"
-                    title="IOTricity Registration Guide"
+                    src="https://www.youtube.com/embed/-Bq2TGLDlDg"
+                    title="IOTricity Post Event Cinematics"
                     frameBorder="0"
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
                     allowFullScreen
@@ -398,9 +394,8 @@ const HomePage = () => {
             {/* Additional Info */}
             <div className="text-center mt-8">
               <p className="text-[10.5px] lg:text-base text-secondary/70 max-w-2xl mx-auto">
-                Having trouble with registration? Feel free to reach out to us
-                through our social media channels or join our Discord server for
-                instant support.
+                Feel free to reach out to us through our social media channels
+                or join our Discord server.
               </p>
             </div>
           </div>


### PR DESCRIPTION
This pull request updates the main section on the home page from a "Registration Guide" to "Post Event Cinematics" for Iotricity Season 2.0. The changes include updating all related text, media, and descriptions to reflect the new focus on event highlights rather than registration instructions.

Content and UI updates:

* Changed section headline and subheadline from "Registration Guide" to "Post Event Cinematics" in both mobile and desktop views (`apps/iotricity/src/app/page.tsx`). [[1]](diffhunk://#diff-e69782517ee677fd9706cfc44e53ecff15de14cad119d8230070d8adc10ec639L331-R338) [[2]](diffhunk://#diff-e69782517ee677fd9706cfc44e53ecff15de14cad119d8230070d8adc10ec639L348-R348)
* Updated the alternative text for the featured GIF image to match the new section focus (`apps/iotricity/src/app/page.tsx`).
* Replaced the descriptive text to highlight the excitement and recap of the event instead of registration instructions (`apps/iotricity/src/app/page.tsx`).
* Updated the embedded YouTube video and its title to showcase the post-event cinematics rather than the registration guide (`apps/iotricity/src/app/page.tsx`).
* Modified the additional info section to remove references to registration support, making it more general (`apps/iotricity/src/app/page.tsx`).